### PR TITLE
[BUG] fix typo in path for development.sh

### DIFF
--- a/development/development.sh
+++ b/development/development.sh
@@ -6,13 +6,13 @@ mv ./Dockerfile ./Dockerfile.production
 mv ./static/pathfinder/environment.ini ./static/pathfinder/environment.production.ini
 
 # copy development versions 
-cp ./deployment/docker-compose.development.yml ./docker-compose.yml
-cp ./deployment/Dockerfile.development ./Dockerfile
-cp ./deployment/environment.development.ini ./static/pathfinder/environment.ini
+cp ./development/docker-compose.development.yml ./docker-compose.yml
+cp ./development/Dockerfile.development ./Dockerfile
+cp ./development/environment.development.ini ./static/pathfinder/environment.ini
 
 # set up launch file for vscode
-mkdir -p .vscode && cp ./deployment/launch.json ./.vscode/launch.json
+mkdir -p .vscode && cp ./development/launch.json ./.vscode/launch.json
 
 # seed .env file with dev presets
 echo "path=\"$(pwd)\"" > ./.env
-cat ./deployment/.env.development >> ./.env
+cat ./development/.env.development >> ./.env


### PR DESCRIPTION
development.sh was not working because of typo in path (deployment <-> development)
```
18:07 $ ./development/development.sh
cp: cannot stat './deployment/docker-compose.development.yml': No such file or directory
cp: cannot stat './deployment/Dockerfile.development': No such file or directory
cp: cannot stat './deployment/environment.development.ini': No such file or directory
cp: cannot stat './deployment/launch.json': No such file or directory
cat: ./deployment/.env.development: No such file or directory
```