### PR TITLE
[BUG] Increase php.ini memory_limit to 256M to avoid PHP OOM on /setup

### DIFF
--- a/static/php/php.ini
+++ b/static/php/php.ini
@@ -1,3 +1,4 @@
+memory_limit = 256M
 upload_max_filesize = 100M
 post_max_size = 108M
 max_input_vars = 5000


### PR DESCRIPTION
See https://github.com/goryn-clade/pathfinder-containers/issues/2