### PR TITLE
Bump php from 7.2.5-fpm-alpine3.7 to 7.2.11-fpm-alpine3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.5-fpm-alpine3.7 as build
+FROM php:7.2.11-fpm-alpine3.7 as build
 
 RUN apk update \
     && apk add --no-cache libpng-dev  zeromq-dev git \


### PR DESCRIPTION
Bumps php from 7.2.5-fpm-alpine3.7 to 7.2.11-fpm-alpine3.7.

---
updated-dependencies:
- dependency-name: php
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>