### PR TITLE
Dockerfile: symlink nginx logs to stdout/stderr for logging non-200 HTTP status codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN composer install
 
 FROM trafex/alpine-nginx-php7:ba1dd422
 RUN apk update && apk add --no-cache busybox-suid sudo php7-redis php7-pdo php7-pdo_mysql php7-fileinfo shadow gettext bash apache2-utils
+# symlink nginx logs to stdout/stderr for supervisord
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+ && ln -sf /dev/stderr /var/log/nginx/error.log
 
 COPY static/nginx/nginx.conf /etc/nginx/templateNginx.conf
 # we need to create sites_enabled directory in order for entrypoint.sh being able to copy file after envsubst


### PR DESCRIPTION
This change results in nginx logging to sdout/sterr -> docker logs. As the nginx config only logs non-200 HTTP status codes, there is not too much whitenoise 