### PR TITLE
Fix for broken eve-scout Thera connections

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "pathfinder"]
-	path = pathfinder
-	url = https://github.com/Thump3d/pathfinder
 [submodule "websocket"]
 	path = websocket
 	url = https://github.com/goryn-clade/pathfinder_websocket
+[submodule "pathfinder"]
+	path = pathfinder
+	url = https://github.com/Thump3d/pathfinder

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "pathfinder"]
 	path = pathfinder
-	url = https://github.com/goryn-clade/pathfinder
+	url = https://github.com/Thump3d/pathfinder
 [submodule "websocket"]
 	path = websocket
 	url = https://github.com/goryn-clade/pathfinder_websocket

--- a/config/pathfinder/pathfinder.ini
+++ b/config/pathfinder/pathfinder.ini
@@ -20,7 +20,7 @@ VERSION                     =   v2.2.2
 ;           Shown on 'licence', 'contact' page.
 ; Syntax:   String
 ; Default:  https://github.com/exodus4d
-CONTACT                     =   https://github.com/samoneilll
+CONTACT                     =   https://github.com/thump3d
 
 ; Public contact email [optional]
 ; Syntax:   String
@@ -31,7 +31,7 @@ EMAIL                       =
 ;           Used for 'licence', 'contact' page.
 ; Syntax:   String
 ; Default:  https://github.com/exodus4d/pathfinder
-REPO                        =   https://github.com/goryn-clade/pathfinder
+REPO                        =   https://github.com/thump3d/pathfinder
 
 ; Show warning on 'login' page if /setup route is active
 ;           DO NOT disable this warning unless /setup route is protected or commented in routes.ini
@@ -402,3 +402,15 @@ GIT_HUB                     =   https://api.github.com
 ; Syntax:   0 | 1
 ; Default:  0
 PERSISTENT_DB_CONNECTIONS   =   1
+
+[PATHFINDER.SYSTEMTAG]
+; Systemtag status
+;           If enabled new systems will be tagged using the defined style
+; Syntax:   0 | 1
+; Default:  0
+STATUS                      =   1
+
+; Naming scheme to use
+; Syntax:   String
+; Default:  countConnections
+STYLE                       =   countConnections

--- a/config/pathfinder/plugin.ini
+++ b/config/pathfinder/plugin.ini
@@ -2,5 +2,5 @@
 MODULES_ENABLED             =   1
 
 [PLUGIN.MODULES]
-DEMO                        =   ./app/ui/module/demo
-EMPTY                       =   ./app/ui/module/empty
+DOTLAN                      =   ./app/ui/module/dotlan
+TAGS                        =   ./app/ui/module/tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "pathfinder-containers",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "pathfinder-containers",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/pathfinder.Dockerfile
+++ b/pathfinder.Dockerfile
@@ -16,8 +16,14 @@ RUN composer install
 
 FROM trafex/alpine-nginx-php7:ba1dd422
 
-RUN apk update && apk add --no-cache busybox-suid sudo php7-redis php7-pdo php7-pdo_mysql php7-fileinfo php7-event shadow gettext bash apache2-utils logrotate
+RUN apk update && apk add --no-cache ca-certificates busybox-suid sudo php7-redis php7-pdo php7-pdo_mysql php7-fileinfo php7-event shadow gettext bash apache2-utils logrotate
 
+
+#fix DST expired cert
+
+RUN sed -i '/^mozilla\/DST_Root_CA_X3.crt$/ s/^/!/' /etc/ca-certificates.conf \
+    && update-ca-certificates \
+  
 # symlink nginx logs to stdout/stderr for supervisord
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
  && ln -sf /dev/stderr /var/log/nginx/error.log


### PR DESCRIPTION
 Removing expired Root CA to fix let's encrypt certs from eve-scout.com

DST Root CA X3   Self-signed Fingerprint SHA256: 0687260331a72403d909f105e69bcf0d32e1bd2493ffc6d9206d11bcd6770739Pin SHA256: Vjs8r4z+80wjNcr1YKepWQboSIRi63WsWXhIMN+eWys=RSA 2048 bits (e 65537) / SHA1withRSA Valid until: Thu, 30 Sep 2021 14:01:15 UTC
