### PR TITLE
Restore fix for bug #23

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
     image: ghcr.io/goryn-clade/pf-websocket:latest
     command: ["--tcpHost", "0.0.0.0"]
     hostname: socket
+    volumes:
+      #- ./websocket:/app 
+      - ./logs:/var/www/html/pathfinder/history/map
     networks:
       pf:
          aliases:


### PR DESCRIPTION
For some reason changes made in `docker-compose.yml` to fix bug #23  are missing in current master branch.

https://github.com/goryn-clade/pathfinder-containers/pull/38

![image](https://github.com/goryn-clade/pathfinder-containers/assets/25212107/85b8c65d-c345-4128-a7ac-b3f453ed72a0)

I'm not sure what if the line `- ./websocket:/app` is necessary, so commented it out. Looking for someone who can investigate why this line was added back then.

I checked this bug fixing on my instance. Without this change map logs are not written. With this change logs are good. But I have not checked if they are logrotated.