### PR TITLE
Update pathfinder.Dockerfile base image

### DIFF
--- a/pathfinder.Dockerfile
+++ b/pathfinder.Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.11-fpm-alpine3.7 as build
+FROM php:7.2.34-fpm-alpine3.12 as build
 
 RUN apk update \
     && apk add --no-cache libpng-dev  zeromq-dev git \


### PR DESCRIPTION
With current base image `php:7.2.11-fpm-alpine3.7` building fails with message

```
No releases available for package "pecl.php.net/redis"
```

Picture: [Screenshot](https://github.com/goryn-clade/pathfinder-containers/assets/25212107/246ca954-a502-4977-92e1-226208f8f539)
Full log: [Log.txt](https://github.com/goryn-clade/pathfinder-containers/files/12287284/Log.txt)

I have investigated problem and discovered some people fix this issue with image updating. So I found latest patch version for current minor: `7.2.34-fpm-alpine3.12`, checked it and it works.

Related issue: https://github.com/docker-library/php/issues/1118