### PR TITLE
Updated php, nginx, mariadb versions to fix security issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/tomaswest/pathfinder
 [submodule "websocket"]
 	path = websocket
-	url = https://github.com/goryn-clade/pathfinder_websocket
+	url = https://github.com/tomaswest/pathfinder_websocket

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "pathfinder"]
 	path = pathfinder
-	url = https://github.com/tomaswest/pathfinder
+	url = https://github.com/goryn-clade/pathfinder
 [submodule "websocket"]
 	path = websocket
-	url = https://github.com/tomaswest/pathfinder_websocket
+	url = https://github.com/goryn-clade/pathfinder_websocket

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "pathfinder"]
 	path = pathfinder
-	url = https://github.com/goryn-clade/pathfinder
+	url = https://github.com/tomaswest/pathfinder
 [submodule "websocket"]
 	path = websocket
 	url = https://github.com/goryn-clade/pathfinder_websocket

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
      - ./pathfinder/export/sql/eve_universe.sql.zip:/eve_universe.sql.zip
     restart: always
   pf-redis:
-    image: redis:6.2.5-alpine3.14
+    image: redis:6.2.13-alpine3.18
     command: ["redis-server", "--appendonly", "yes"]
     hostname: redis
     volumes:
@@ -37,7 +37,7 @@ services:
     restart: always
   pf:
     hostname: "pathfinder"
-    image: ghcr.io/goryn-clade/pathfinder:latest
+    image: ghcr.io/westtom/pathfinder:latest
     env_file:
     - .env
     labels:
@@ -68,7 +68,7 @@ services:
       - pf-socket
     restart: always
   traefik:
-    image: "traefik:v2.3"
+    image: "traefik:v2.10.4"
     container_name: "traefik"
     command:
       - "--log.level=ERROR"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     restart: always
   pf:
     hostname: "pathfinder"
-    image: ghcr.io/westtom/pathfinder:latest
+    image: westtom/pathfinder:latest
     env_file:
     - .env
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3.8"
 
 services:
   pfdb:
-    image: bianjp/mariadb-alpine:latest
+    image: westtom/mariadb-alpine:latest
+    container_name: mariadb
     environment:
       MYSQL_ROOT_PASSWORD: $MYSQL_PASSWORD
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,12 @@ version: "3.8"
 
 services:
   pfdb:
-    image: westtom/mariadb-alpine:latest
+    image: mariadb:latest
     container_name: mariadb
     environment:
-      MYSQL_ROOT_PASSWORD: $MYSQL_PASSWORD
+      MARIADB_ROOT_PASSWORD: $MYSQL_PASSWORD
+      MARIADB_AUTO_UPGRADE: "1"
+      MARIADB_INITDB_SKIP_TZINFO: "1"
     networks:
       pf:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   pf-redis:
     image: redis:6.2.13-alpine3.18
     command: ["redis-server", "--appendonly", "yes"]
-    hostname: redis
+    container_name: redis
     volumes:
       - redis_data:/data
     networks:
@@ -29,14 +29,14 @@ services:
   pf-socket:
     image: ghcr.io/goryn-clade/pf-websocket:latest
     command: ["--tcpHost", "0.0.0.0"]
-    hostname: socket
+    container_name: socket
     networks:
       pf:
          aliases:
            - "$PATHFINDER_SOCKET_HOST"
     restart: always
   pf:
-    hostname: "pathfinder"
+    container_name: "pathfinder"
     image: westtom/pathfinder:latest
     env_file:
     - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     restart: always
   pf:
     container_name: "pathfinder"
-    image: westtom/pathfinder:latest
+    image: ghcr.io/goryn-clade/pathfinder:latest
     env_file:
     - .env
     labels:

--- a/pathfinder.Dockerfile
+++ b/pathfinder.Dockerfile
@@ -14,11 +14,16 @@ WORKDIR /app
 RUN composer self-update 2.5.8
 RUN composer install
 
-FROM alpine:3.15
-USER root
-RUN apk update && apk add --no-cache php7 php7-fpm php7-opcache php7-mysqli php7-json php7-openssl php7-curl \
-    php7-zlib php7-xml php7-phar php7-intl php7-dom php7-xmlreader php7-ctype php7-session \
-    php7-mbstring php7-gd nginx supervisor curl busybox-suid sudo php7-redis php7-pdo php7-pdo_mysql \
+FROM alpine:3.12
+
+# Add application
+RUN mkdir -p /var/www/html
+
+HEALTHCHECK --timeout=10s CMD curl --silent --fail http://127.0.0.1/fpm-ping
+
+RUN apk update && apk add --no-cache php7 php7-fpm php7-mysqli php7-json php7-openssl php7-curl \
+    php7-zlib php7-xml php7-phar php7-intl php7-dom php7-xmlreader php7-ctype \
+    php7-mbstring php7-gd nginx supervisor curl busybox-suid sudo php7-redis php7-pdo php7-pdo_mysql php7-openssl \
     php7-fileinfo php7-event shadow gettext bash apache2-utils logrotate ca-certificates
 
 # fix expired DST Cert
@@ -44,7 +49,7 @@ COPY static/crontab.txt /var/crontab.txt
 # Configure supervisord
 COPY static/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY static/entrypoint.sh   /
-RUN mkdir -p /var/www/html
+
 WORKDIR /var/www/html
 COPY  --chown=nobody --from=build /app  pathfinder
 


### PR DESCRIPTION
Currently used php and mariadb version are outdated and have a lot of security issues, as mentioned https://github.com/goryn-clade/pathfinder/issues/180
Also custom images of mariadb and nginx-php7 are not actively maintained by their authors.
So we are not using them, and switch to official mariadb image, and alpine with latest php7 version.
