### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,9 @@ services:
           - "$REDIS_HOST"
     logging:
       driver: json-file
-      options: "5m"
-      max-file: "3"
+      options:
+        max-size: "5m"
+        max-file: "3"
     restart: always
   pf-socket:
     image: ghcr.io/goryn-clade/pf-websocket:latest


### PR DESCRIPTION
Fixed missing max-size logging declaration for pf-redis, which caused validation issues upon compose.